### PR TITLE
Improved outbox processor performance

### DIFF
--- a/Example/ModularMonolith.Database/ModularMonolith.Database.csproj
+++ b/Example/ModularMonolith.Database/ModularMonolith.Database.csproj
@@ -29,6 +29,7 @@
     <EmbeddedResource Include="Scripts\007_Create_Read_Schema.sql" />
     <EmbeddedResource Include="Scripts\008_Create_Subjects_And_Locations.sql" />
     <EmbeddedResource Include="Scripts\009_Create_Exam_View.sql" />
+    <EmbeddedResource Include="Scripts\010_Remove_SerializedEvent_ProcessedOn_Column.sql" />
     <EmbeddedResource Include="TestData\001_Subjects_And_Locations.sql" />
   </ItemGroup>
 

--- a/Example/ModularMonolith.Database/Scripts/010_Remove_SerializedEvent_ProcessedOn_Column.sql
+++ b/Example/ModularMonolith.Database/Scripts/010_Remove_SerializedEvent_ProcessedOn_Column.sql
@@ -1,0 +1,10 @@
+IF EXISTS (
+  SELECT *
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_NAME = 'SerializedEvent' and TABLE_SCHEMA = 'events' AND COLUMN_NAME = 'ProcessedOn'
+)
+BEGIN
+    ALTER TABLE [events].[SerializedEvent]
+    DROP COLUMN ProcessedOn
+END
+GO

--- a/Example/ModularMonolith.Database/Scripts/010_Remove_SerializedEvent_ProcessedOn_Column.sql
+++ b/Example/ModularMonolith.Database/Scripts/010_Remove_SerializedEvent_ProcessedOn_Column.sql
@@ -7,4 +7,3 @@ BEGIN
     ALTER TABLE [events].[SerializedEvent]
     DROP COLUMN ProcessedOn
 END
-GO

--- a/Example/ModularMonolith.EventsPublisher/EventsPublisherStartup.cs
+++ b/Example/ModularMonolith.EventsPublisher/EventsPublisherStartup.cs
@@ -1,4 +1,5 @@
-﻿using Hexure.EventsPublisher;
+﻿using ExternalSystem.Events.Locations;
+using Hexure.EventsPublisher;
 using Hexure.MassTransit;
 using Hexure.MassTransit.RabbitMq.Settings;
 using Hexure.Time;
@@ -8,6 +9,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using ModularMonolith.Configuration;
 using ModularMonolith.Dependencies;
+using ModularMonolith.Exams.Events;
 using ModularMonolith.Persistence;
 using ModularMonolith.Registrations.Contracts.Events;
 
@@ -26,6 +28,8 @@ namespace ModularMonolith.EventsPublisher
                 .WithDbContext<MonolithDbContext>()
                 .WithTransactionProvider<MonolithDbContext>()
                 .WithEventsFromAssemblyOfType<RegistrationPaid>()
+                .WithEventsFromAssemblyOfType<LocationAdded>()
+                .WithEventsFromAssemblyOfType<ExamPlanned>()
                 .WithPersistence(services =>
                 {
                     services.AddPersistence(configuration.GetConnectionString("Database"));

--- a/Example/ModularMonolith.EventsPublisher/ModularMonolith.EventsPublisher.csproj
+++ b/Example/ModularMonolith.EventsPublisher/ModularMonolith.EventsPublisher.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Source\Hexure.EventsPublisher\Hexure.EventsPublisher.csproj" />
     <ProjectReference Include="..\..\Source\Hexure.Workers\Hexure.Workers.csproj" />
+    <ProjectReference Include="..\ExternalSystem.Events\ExternalSystem.Events.csproj" />
     <ProjectReference Include="..\ModularMonolith.Configuration\ModularMonolith.Configuration.csproj" />
     <ProjectReference Include="..\ModularMonolith.Dependencies\ModularMonolith.Dependencies.csproj" />
     <ProjectReference Include="..\ModularMonolith.Persistence\ModularMonolith.Persistence.csproj" />

--- a/Example/ModularMonolith.EventsPublisher/appsettings.json
+++ b/Example/ModularMonolith.EventsPublisher/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "Database": "Data Source=(local);Initial Catalog=Hexure;Connection Timeout=30;Integrated Security=True;MultipleActiveResultSets=True;Timeout=30;"
+    "Database": "Data Source=(local);Initial Catalog=Hexure;Connection Timeout=30;Integrated Security=True;MultipleActiveResultSets=False;Timeout=30;"
   },
   "Logging": {
     "LogLevel": {
@@ -11,7 +11,7 @@
   },
   "Settings": {
     "Delay": "00:00:10",
-    "BatchSize": 20
+    "BatchSize": 1000
   },
   "Bus": {
     "Host": "rabbitmq://127.0.0.1:3001",

--- a/Example/ModularMonolith.Exams.Language/ExamId.cs
+++ b/Example/ModularMonolith.Exams.Language/ExamId.cs
@@ -3,11 +3,13 @@ using Hexure.Results;
 using Hexure.Results.Extensions;
 using ModularMonolith.Errors;
 using ModularMonolith.Exams.Language.Validators;
+using Newtonsoft.Json;
 
 namespace ModularMonolith.Exams.Language
 {
     public class ExamId : Identifier
     {
+        [JsonConstructor]
         internal ExamId(long value) : base(value)
         {
         }

--- a/Source/Hexure.EntityFrameworkCore.SqlServer/Events/SerializedEventRepository.cs
+++ b/Source/Hexure.EntityFrameworkCore.SqlServer/Events/SerializedEventRepository.cs
@@ -20,7 +20,6 @@ namespace Hexure.EntityFrameworkCore.SqlServer.Events
             return await DbContext
                 .SerializedEvents
                 .WithHint("XLOCK, ROWLOCK, READPAST")
-                .Where(entity => !entity.ProcessedOn.HasValue)
                 .OrderBy(entity => entity.Id)
                 .Take(batchSize)
                 .ToListAsync();

--- a/Source/Hexure.EntityFrameworkCore/Events/Entites/SerializedEventEntity.cs
+++ b/Source/Hexure.EntityFrameworkCore/Events/Entites/SerializedEventEntity.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Hexure.Events.Serialization;
+﻿using Hexure.Events.Serialization;
 using Hexure.Results;
 using Hexure.Results.Extensions;
 
@@ -24,17 +23,7 @@ namespace Hexure.EntityFrameworkCore.Events.Entites
         }
 
         public long Id { get; private set; }
-        public DateTime? ProcessedOn { get; private set; }
         public SerializedEvent SerializedEvent { get; private set; }
-
-        public Result MarkAsProcessed(DateTime processedOn)
-        {
-            if (ProcessedOn.HasValue)
-                return Result.Fail(SerializedEventEntityErrors.EventAlreadyProcessed.Build());
-
-            ProcessedOn = processedOn;
-            return Result.Ok();
-        }
 
         public static Result<SerializedEventEntity> Create(SerializedEvent serializedEvent)
         {

--- a/Source/Hexure.EntityFrameworkCore/Events/Repositories/SerializedEventRepository.cs
+++ b/Source/Hexure.EntityFrameworkCore/Events/Repositories/SerializedEventRepository.cs
@@ -8,6 +8,7 @@ namespace Hexure.EntityFrameworkCore.Events.Repositories
     {
         Task<IReadOnlyCollection<SerializedEventEntity>> GetUnpublishedEventsAsync(int batchSize);
         Task SaveChangesAsync();
+        void RemoveRange(IEnumerable<SerializedEventEntity> processedEvents);
     }
 
     public abstract class AbstractSerializedEventRepository : ISerializedEventRepository
@@ -24,6 +25,11 @@ namespace Hexure.EntityFrameworkCore.Events.Repositories
         public Task SaveChangesAsync()
         {
             return DbContext.SaveChangesAsync();
+        }
+
+        public void RemoveRange(IEnumerable<SerializedEventEntity> processedEvents)
+        {
+            DbContext.SerializedEvents.RemoveRange(processedEvents);
         }
     }
 }

--- a/Source/Hexure.EventsPublisher/EventsPublisher.cs
+++ b/Source/Hexure.EventsPublisher/EventsPublisher.cs
@@ -1,11 +1,12 @@
 ﻿using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Hexure.EntityFrameworkCore;
 using Hexure.EntityFrameworkCore.Events.Repositories;
 using Hexure.Events.Serialization;
+using Hexure.Results;
 using Hexure.Results.Extensions;
-using Hexure.Time;
 using MassTransit;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.DependencyInjection;
@@ -17,17 +18,16 @@ namespace Hexure.EventsPublisher
     {
         private readonly EventsPublisherSettings _settings;
         private readonly IBusControl _busControl;
-        private readonly ISystemTimeProvider _systemTimeProvider;
         private readonly IEventDeserializer _eventDeserializer;
         private readonly IServiceProvider _serviceProvider;
 
-        public EventsPublisher(EventsPublisherSettings settings, IBusControl busControl,
-            ISystemTimeProvider systemTimeProvider, IEventDeserializer eventDeserializer,
+        public EventsPublisher(EventsPublisherSettings settings,
+            IBusControl busControl,
+            IEventDeserializer eventDeserializer,
             IServiceProvider serviceProvider)
         {
             _settings = settings;
             _busControl = busControl;
-            _systemTimeProvider = systemTimeProvider;
             _eventDeserializer = eventDeserializer;
             _serviceProvider = serviceProvider;
         }
@@ -42,43 +42,13 @@ namespace Hexure.EventsPublisher
                 {
                     try
                     {
-                        using (var scopedContainer = _serviceProvider.CreateScope())
+                        var allEventsPublished = false;
+                        while (!allEventsPublished)
                         {
-                            var transactionProvider =
-                                scopedContainer.ServiceProvider.GetRequiredService<ITransactionProvider>();
-                            var serializedEventRepository = scopedContainer.ServiceProvider
-                                .GetRequiredService<ISerializedEventRepository>();
-
-                            await transactionProvider.BeginTransactionAsync();
-                            Console.WriteLine($"{DateTime.UtcNow} Publishing (batch size: {_settings.BatchSize})...");
-                            var eventsToPublish =
-                                await serializedEventRepository.GetUnpublishedEventsAsync(_settings.BatchSize);
-
-                            foreach (var serializedEventEntity in eventsToPublish)
-                            {
-                                try
-                                {
-                                    await _eventDeserializer.Deserialize(serializedEventEntity.SerializedEvent)
-                                        .OnSuccess(async @event =>
-                                        {
-                                            await _busControl.Publish(@event, stoppingToken);
-                                        });
-
-                                    await serializedEventEntity.MarkAsProcessed(_systemTimeProvider.UtcNow)
-                                        .OnSuccess(() => serializedEventRepository.SaveChangesAsync())
-                                        .OnFailure(errors =>
-                                            throw new InvalidOperationException(JsonConvert.SerializeObject(errors)));
-                                }
-                                catch (Exception ex)
-                                {
-                                    Console.WriteLine(ex.ToString());
-                                }
-                            }
-
-                            await transactionProvider.CommitTransactionAsync();
+                            allEventsPublished = await PublishAsync(stoppingToken);
                         }
                     }
-                    catch (SqlException ex)
+                    catch (Exception ex) when (ex is SqlException || ex is InvalidOperationException)
                     {
                         Console.WriteLine(ex.ToString());
                         //TODO: Logging
@@ -89,10 +59,41 @@ namespace Hexure.EventsPublisher
                     }
                 }
             }
-            catch
+            catch (Exception ex)
             {
+                Console.WriteLine(ex.ToString());
                 await _busControl.StopAsync(stoppingToken);
             }
+        }
+
+        private async Task<bool> PublishAsync(CancellationToken stoppingToken)
+        {
+            using var scopedContainer = _serviceProvider.CreateScope();
+            var transactionProvider =
+                scopedContainer.ServiceProvider.GetRequiredService<ITransactionProvider>();
+            var serializedEventRepository = scopedContainer.ServiceProvider
+                .GetRequiredService<ISerializedEventRepository>();
+
+            await transactionProvider.BeginTransactionAsync();
+            Console.WriteLine(
+                $"{DateTime.UtcNow} Publishing (batch size: {_settings.BatchSize})...");
+            var eventsToPublish =
+                await serializedEventRepository.GetUnpublishedEventsAsync(_settings.BatchSize);
+
+            var publishActions = eventsToPublish
+                .Select(serializedEventEntity => _eventDeserializer.Deserialize(serializedEventEntity.SerializedEvent)
+                    .OnSuccess(@event => _busControl.Publish(@event, stoppingToken)));
+
+            Result.Combine(await Task.WhenAll(publishActions))
+                .OnSuccess(() => serializedEventRepository.RemoveRange(eventsToPublish))
+                .OnFailure(errors => throw new InvalidOperationException(JsonConvert.SerializeObject(errors)));
+
+            await transactionProvider.CommitTransactionAsync();
+
+            Console.WriteLine(
+                $"{DateTime.UtcNow} Publish completed (events: {eventsToPublish.Count}, batch size: {_settings.BatchSize})...");
+
+            return eventsToPublish.Count < _settings.BatchSize;
         }
     }
 }

--- a/Source/Hexure.MassTransit/RabbitMq/ServiceCollectionExtensions.cs
+++ b/Source/Hexure.MassTransit/RabbitMq/ServiceCollectionExtensions.cs
@@ -39,7 +39,7 @@ namespace Hexure.MassTransit.RabbitMq
                     busConfigurator.ReceiveEndpointForEachConsumer(provider, rabbitMqSettings.QueuePrefix, withConsumersFromAssemblies,
                         configurator =>
                         {
-                            configurator.PrefetchCount = 3;
+                            configurator.PrefetchCount = 25;
                             configurator.UseMessageRetry(x =>
                                 x.Incremental(2, TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(12)));
                         });
@@ -69,6 +69,11 @@ namespace Hexure.MassTransit.RabbitMq
                     {
                         hostConfigurator.Username(rabbitMqSettings.Username);
                         hostConfigurator.Password(rabbitMqSettings.Password);
+                        hostConfigurator.ConfigureBatchPublish(publishConfigurator =>
+                        {
+                            publishConfigurator.Enabled = true;
+                            publishConfigurator.Timeout = TimeSpan.FromMilliseconds(50);
+                        });
                     });
 
                     factoryConfigurator.MessageTopology.SetEntityNameFormatter(

--- a/Source/Hexure.Results/Extensions/AsyncResultExtensionsLeftOperand.cs
+++ b/Source/Hexure.Results/Extensions/AsyncResultExtensionsLeftOperand.cs
@@ -32,6 +32,12 @@ namespace Hexure.Results.Extensions
             Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
             return result.OnSuccess(action);
         }
+        
+        public static async Task<Result<T>> OnFailure<T>(this Task<Result<T>> resultTask, Action<IReadOnlyList<Error>> action)
+        {
+            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            return result.OnFailure(action);
+        }
 
         public static async Task<Result> OnFailure(this Task<Result> resultTask, Action<IReadOnlyList<Error>> action)
         {

--- a/Source/Hexure.Results/Result.cs
+++ b/Source/Hexure.Results/Result.cs
@@ -281,6 +281,18 @@ namespace Hexure.Results
             return Fail(errors);
         }
 
+        [DebuggerStepThrough]
+        public static Result Combine<T>(params Result<T>[] results)
+        {
+            List<Result<T>> failedResults = results.Where(x => x.IsFailure).ToList();
+
+            if (!failedResults.Any())
+                return Ok();
+
+            Error[] errors = failedResults.SelectMany(x => x.Error).ToArray();
+            return Fail(errors);
+        }
+
         public bool Violates(Error.ErrorType invariant) => _logic.Violates(invariant);
 
         public bool ViolatesOnly(Error.ErrorType invariant) => _logic.ViolatesOnly(invariant);


### PR DESCRIPTION
Test environment - local single instance of RabbitMQ hosted on Docker for Windows

Before: ~10 messages / second
After: ~3-4k messages / second (300-400 times more than before)